### PR TITLE
change itemIds propType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## next
+* itemIds doesn't have to be a Immutable list anymore
 
 ## 0.4.0
 * Removed font-awesome library, instead used react-icons

--- a/src/list-items/item-position/item-position.js
+++ b/src/list-items/item-position/item-position.js
@@ -1,16 +1,21 @@
+import { List } from 'immutable';
+
 class ItemPosition {
   constructor() {
     this.data = this.getInitial();
   }
 
-  set = (list, itemId) => {
+  set = (srcList, itemId) => {
+    let list = srcList;
+    if (!List.isList(list)) list = List(srcList);
+
     const index = list.findIndex(i => i === itemId);
     if (index !== -1) {
       this.data.previous = index > 0 ? list.get(index - 1) : 0;
       this.data.next = index !== list.size - 1 ? list.get(index + 1) : 0;
       this.data.string = `${(index + 1)}/${list.size}`;
     }
-  }
+  };
 
   getNext = () => this.data.next;
 

--- a/src/list-items/list-items.component.jsx
+++ b/src/list-items/list-items.component.jsx
@@ -15,7 +15,16 @@ export default class ListItems extends React.PureComponent {
     id: PropTypes.string.isRequired,
     itemElement: PropTypes.element,
     itemId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-    itemIds: ImmutablePropTypes.list.isRequired,
+    itemIds: PropTypes.oneOfType([
+      ImmutablePropTypes.list,
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+          PropTypes.shape({}),
+        ]),
+      ),
+    ]).isRequired,
   };
 
   static defaultProps = {
@@ -56,11 +65,9 @@ export default class ListItems extends React.PureComponent {
         </span>
         <span className="oc-list-items-element">
           {itemElement ||
-            (
-              <span className="oc-list-items-string">
-                {this.itemPosition.getString()}
-              </span>
-            )
+          (
+            <span className="oc-list-items-string">{this.itemPosition.getString()}</span>
+          )
           }
         </span>
         <span


### PR DESCRIPTION
itemIds can now also be a regular list. Best solution (in my opinion) would be to remove Immutable altogether, but that's something we probably have to discuss with original developers.